### PR TITLE
Add name + version to be npm installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "ddem-observation-server",
+  "version": "0.0.0",
   "devDependencies": {
     "level": "^1.5.0",
     "osm-p2p": "^1.4.0"


### PR DESCRIPTION
`npm install` fails without these (when pointed at GitHub).