### PR TITLE
Pipe request to multiple streams

### DIFF
--- a/identify-image-stream.js
+++ b/identify-image-stream.js
@@ -1,18 +1,21 @@
 var identify = require('imghdr').what
+var jpeg = require('jpeg-marker-stream')
 var peek = require('peek-stream')
 
-module.exports = function (stream, done) {
-  var parse = peek({
+module.exports = function () {
+  return peek({
     maxBuffer: 10,
     newline: false
   }, function (data, swap) {
-    console.log(data)
     var type = identify(data)
-    if (!type || type.length === 0) {
-      done(new Error('unknown type'))
-    } else {
-      done(null, type[0])
+    switch (type[0]) {
+      case 'jpg':
+      case 'jpeg': {
+        return swap(null, jpeg())
+      }
+
+      default:
+        return swap(new Error('unknown type'))
     }
   })
-  stream.pipe(parse)
 }


### PR DESCRIPTION
One to buffer data ahead of the file type / name being known, one to detect the file type and determine an appropriate filename.

There were 2 snags with the previous implementation: `pump` was doing what it was supposed to, but when `jpeg-marker-stream` ran into the `unknown code: 0xd0` error, it would cancel the entire stream pipeline (as it should when it encountered an error).

The second was that `r`, the `through2` stream that was being held back from being piped to the hyperdrive archive, wasn't being buffered, and thus either dropping data or preventing the parsing stream from continuing.